### PR TITLE
bugfix: redirect path

### DIFF
--- a/src/Pages/elements/sidebar.php
+++ b/src/Pages/elements/sidebar.php
@@ -43,7 +43,7 @@ if ($_SESSION['admin'] === 1) { ?>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link collapsed" href="../schoolClassModule.php">                            
+                        <a class="nav-link collapsed" href="schoolClassModule.php">                            
                             <i class="fa-solid fa-chalkboard-user class-i"></i>                        
                             <span>Turmas</span>
                         </a>


### PR DESCRIPTION
# Correção do caminho de redirecionamento de páginas

> o caminho da página para turmas agora esta apontando para o caminho correto.

#### Código anterior
```HTML
<a class="nav-link collapsed" href="../schoolClassModule.php">                            
```
#### Código novo
```HTML                       
<a class="nav-link collapsed" href="schoolClassModule.php"> 
```