### PR TITLE
bugfix: special characters in the class shift.

### DIFF
--- a/src/Pages/schoolClassModule.php
+++ b/src/Pages/schoolClassModule.php
@@ -42,7 +42,14 @@ if (empty($_SESSION['user']) || empty($_SESSION['password'])) {
                 <h5 class="card-title class-identifier">TURMA <?php echo "{$class->getYear()}{$class->getIdentifier()}";?></h5>
                 <div class="class-text">
                     <p class="card-text class-shift">
-                        <?php echo $class->getShift();?>
+                        <?php 
+                        if ($class->getShift() === 'manha'){
+                            $shift = 'MANHÃ';
+                        } else {
+                            $shift = 'TARDE';
+                        }
+                        echo $shift;
+                        ?>
                     </p>
                     <p class="card-text class-students">
                         <?php echo $studentController->numberOfStudentsByClass($studentRepository, $class->getId());?> ESTUDANTES


### PR DESCRIPTION
# Remoção de caracteres especiais

> Os dados referente ao **turno** agora estão sendo cadastrados no banco sem o acento gráfico e é feito uma formatação dentro do PHP para transformar a **string** pro padrão correto a ser exibido.